### PR TITLE
feat(rule): Disable enforcing class member visibility declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'ordered-imports': false,
     'interface-name': [true, 'never-prefix'],
     'no-implicit-dependencies': [true, 'dev'],
-    'no-submodule-imports': false
+    'no-submodule-imports': false,
+    'member-access': false
   }
 }


### PR DESCRIPTION
Stop enforcing that every member of a class have a visibility declaration. Aside from the code feeling very java/c#, it makes React component definitions unnecessarily noisy.