### PR TITLE
feat(rule): Enforce no-floating-promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
 module.exports = {
-  extends: [
-    'tslint:latest', 
-    'tslint-config-prettier'
-  ],
+  extends: ['tslint:latest', 'tslint-config-prettier'],
   rules: {
-    'object-literal-sort-keys': false,
-    'ordered-imports': false,
     'interface-name': [true, 'never-prefix'],
+    'member-access': false,
+    'no-floating-promises': true,
     'no-implicit-dependencies': [true, 'dev'],
     'no-submodule-imports': false,
-    'member-access': false
+    'object-literal-sort-keys': false,
+    'ordered-imports': false
   }
-}
+};


### PR DESCRIPTION
This rule is really handy for catching missing `await`s:

```text
ERROR: .../index.test.ts:112:9 - Promises must be handled appropriately
```

<https://palantir.github.io/tslint/rules/no-floating-promises/>

I've also sorted the object literal keys in index.js to annoy people.