### PR TITLE
feat(rules): Add stricter async/await rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 module.exports = {
   extends: ['tslint:latest', 'tslint-config-prettier'],
   rules: {
+    'await-promise': true,
     'interface-name': [true, 'never-prefix'],
     'member-access': false,
+    'no-async-without-await': true,
     'no-floating-promises': true,
     'no-implicit-dependencies': [true, 'dev'],
     'no-submodule-imports': false,


### PR DESCRIPTION
This adds two rules that have been used in Indirect Apply for a while:

- [`await-promise`](https://palantir.github.io/tslint/rules/await-promise/) triggers when awaiting on a non-promise value. While this is defined to just return the value it's almost certainly an error.

- [`no-async-without-await`](https://palantir.github.io/tslint/rules/no-async-without-await/) triggers when a function is `async` without an `await` or a `return`. These functions can typically either be synchronous or the programmer forgot an `await`.